### PR TITLE
Atlas v2 conversion: ggsegSchaefer

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -10,3 +10,4 @@ pkgdown
 docs
 ^.*\.zip$
 ^README\.qmd$
+^codemeta\.json$

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -1,0 +1,33 @@
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+name: code-quality
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::lintr, local::.
+          needs: lint
+
+      - name: Lint
+        run: lintr::lint_package()
+        shell: Rscript {0}
+        env:
+          LINTR_ERROR_ON_LINT: true

--- a/.lintr
+++ b/.lintr
@@ -1,0 +1,3 @@
+exclusions: list(
+  "data-raw"
+)

--- a/.lintr
+++ b/.lintr
@@ -1,3 +1,1 @@
-exclusions: list(
-  "data-raw"
-)
+exclusions: list("data-raw")

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,6 +31,8 @@ Suggests:
     rmarkdown,
     testthat (>= 3.0.0),
     vdiffr
+Remotes:
+    ggsegverse/ggseg
 URL: https://github.com/ggsegverse/ggsegSchaefer
 BugReports: https://github.com/ggsegverse/ggsegSchaefer/issues
 Roxygen: list(markdown = TRUE)

--- a/R/data.R
+++ b/R/data.R
@@ -8,6 +8,7 @@
 #' 3D vertex indices for [ggseg3d::ggseg3d()].
 #'
 #' @family ggseg_atlases
+#' @family cortical_atlases
 #'
 #' @references Schaefer A, et al. (2018). "Local-Global Parcellation of the
 #'   Human Cerebral Cortex from Intrinsic Functional Connectivity MRI."
@@ -30,6 +31,7 @@ schaefer7_100 <- function() .schaefer7_100
 #' 3D vertex indices for [ggseg3d::ggseg3d()].
 #'
 #' @family ggseg_atlases
+#' @family cortical_atlases
 #'
 #' @references Schaefer A, et al. (2018). "Local-Global Parcellation of the
 #'   Human Cerebral Cortex from Intrinsic Functional Connectivity MRI."
@@ -51,6 +53,7 @@ schaefer7_200 <- function() .schaefer7_200
 #' 3D vertex indices for [ggseg3d::ggseg3d()].
 #'
 #' @family ggseg_atlases
+#' @family cortical_atlases
 #'
 #' @references Schaefer A, et al. (2018). "Local-Global Parcellation of the
 #'   Human Cerebral Cortex from Intrinsic Functional Connectivity MRI."
@@ -72,6 +75,7 @@ schaefer7_300 <- function() .schaefer7_300
 #' 3D vertex indices for [ggseg3d::ggseg3d()].
 #'
 #' @family ggseg_atlases
+#' @family cortical_atlases
 #'
 #' @references Schaefer A, et al. (2018). "Local-Global Parcellation of the
 #'   Human Cerebral Cortex from Intrinsic Functional Connectivity MRI."
@@ -93,6 +97,7 @@ schaefer7_400 <- function() .schaefer7_400
 #' 3D vertex indices for [ggseg3d::ggseg3d()].
 #'
 #' @family ggseg_atlases
+#' @family cortical_atlases
 #'
 #' @references Schaefer A, et al. (2018). "Local-Global Parcellation of the
 #'   Human Cerebral Cortex from Intrinsic Functional Connectivity MRI."
@@ -114,6 +119,7 @@ schaefer7_500 <- function() .schaefer7_500
 #' 3D vertex indices for [ggseg3d::ggseg3d()].
 #'
 #' @family ggseg_atlases
+#' @family cortical_atlases
 #'
 #' @references Schaefer A, et al. (2018). "Local-Global Parcellation of the
 #'   Human Cerebral Cortex from Intrinsic Functional Connectivity MRI."
@@ -135,6 +141,7 @@ schaefer7_600 <- function() .schaefer7_600
 #' 3D vertex indices for [ggseg3d::ggseg3d()].
 #'
 #' @family ggseg_atlases
+#' @family cortical_atlases
 #'
 #' @references Schaefer A, et al. (2018). "Local-Global Parcellation of the
 #'   Human Cerebral Cortex from Intrinsic Functional Connectivity MRI."
@@ -156,6 +163,7 @@ schaefer7_700 <- function() .schaefer7_700
 #' 3D vertex indices for [ggseg3d::ggseg3d()].
 #'
 #' @family ggseg_atlases
+#' @family cortical_atlases
 #'
 #' @references Schaefer A, et al. (2018). "Local-Global Parcellation of the
 #'   Human Cerebral Cortex from Intrinsic Functional Connectivity MRI."
@@ -177,6 +185,7 @@ schaefer7_800 <- function() .schaefer7_800
 #' 3D vertex indices for [ggseg3d::ggseg3d()].
 #'
 #' @family ggseg_atlases
+#' @family cortical_atlases
 #'
 #' @references Schaefer A, et al. (2018). "Local-Global Parcellation of the
 #'   Human Cerebral Cortex from Intrinsic Functional Connectivity MRI."
@@ -198,6 +207,7 @@ schaefer7_900 <- function() .schaefer7_900
 #' 3D vertex indices for [ggseg3d::ggseg3d()].
 #'
 #' @family ggseg_atlases
+#' @family cortical_atlases
 #'
 #' @references Schaefer A, et al. (2018). "Local-Global Parcellation of the
 #'   Human Cerebral Cortex from Intrinsic Functional Connectivity MRI."
@@ -220,6 +230,7 @@ schaefer7_1000 <- function() .schaefer7_1000
 #' 3D vertex indices for [ggseg3d::ggseg3d()].
 #'
 #' @family ggseg_atlases
+#' @family cortical_atlases
 #'
 #' @references Schaefer A, et al. (2018). "Local-Global Parcellation of the
 #'   Human Cerebral Cortex from Intrinsic Functional Connectivity MRI."
@@ -241,6 +252,7 @@ schaefer17_100 <- function() .schaefer17_100
 #' 3D vertex indices for [ggseg3d::ggseg3d()].
 #'
 #' @family ggseg_atlases
+#' @family cortical_atlases
 #'
 #' @references Schaefer A, et al. (2018). "Local-Global Parcellation of the
 #'   Human Cerebral Cortex from Intrinsic Functional Connectivity MRI."
@@ -262,6 +274,7 @@ schaefer17_200 <- function() .schaefer17_200
 #' 3D vertex indices for [ggseg3d::ggseg3d()].
 #'
 #' @family ggseg_atlases
+#' @family cortical_atlases
 #'
 #' @references Schaefer A, et al. (2018). "Local-Global Parcellation of the
 #'   Human Cerebral Cortex from Intrinsic Functional Connectivity MRI."
@@ -283,6 +296,7 @@ schaefer17_300 <- function() .schaefer17_300
 #' 3D vertex indices for [ggseg3d::ggseg3d()].
 #'
 #' @family ggseg_atlases
+#' @family cortical_atlases
 #'
 #' @references Schaefer A, et al. (2018). "Local-Global Parcellation of the
 #'   Human Cerebral Cortex from Intrinsic Functional Connectivity MRI."
@@ -304,6 +318,7 @@ schaefer17_400 <- function() .schaefer17_400
 #' 3D vertex indices for [ggseg3d::ggseg3d()].
 #'
 #' @family ggseg_atlases
+#' @family cortical_atlases
 #'
 #' @references Schaefer A, et al. (2018). "Local-Global Parcellation of the
 #'   Human Cerebral Cortex from Intrinsic Functional Connectivity MRI."
@@ -325,6 +340,7 @@ schaefer17_500 <- function() .schaefer17_500
 #' 3D vertex indices for [ggseg3d::ggseg3d()].
 #'
 #' @family ggseg_atlases
+#' @family cortical_atlases
 #'
 #' @references Schaefer A, et al. (2018). "Local-Global Parcellation of the
 #'   Human Cerebral Cortex from Intrinsic Functional Connectivity MRI."
@@ -346,6 +362,7 @@ schaefer17_600 <- function() .schaefer17_600
 #' 3D vertex indices for [ggseg3d::ggseg3d()].
 #'
 #' @family ggseg_atlases
+#' @family cortical_atlases
 #'
 #' @references Schaefer A, et al. (2018). "Local-Global Parcellation of the
 #'   Human Cerebral Cortex from Intrinsic Functional Connectivity MRI."
@@ -367,6 +384,7 @@ schaefer17_700 <- function() .schaefer17_700
 #' 3D vertex indices for [ggseg3d::ggseg3d()].
 #'
 #' @family ggseg_atlases
+#' @family cortical_atlases
 #'
 #' @references Schaefer A, et al. (2018). "Local-Global Parcellation of the
 #'   Human Cerebral Cortex from Intrinsic Functional Connectivity MRI."
@@ -388,6 +406,7 @@ schaefer17_800 <- function() .schaefer17_800
 #' 3D vertex indices for [ggseg3d::ggseg3d()].
 #'
 #' @family ggseg_atlases
+#' @family cortical_atlases
 #'
 #' @references Schaefer A, et al. (2018). "Local-Global Parcellation of the
 #'   Human Cerebral Cortex from Intrinsic Functional Connectivity MRI."
@@ -409,6 +428,7 @@ schaefer17_900 <- function() .schaefer17_900
 #' 3D vertex indices for [ggseg3d::ggseg3d()].
 #'
 #' @family ggseg_atlases
+#' @family cortical_atlases
 #'
 #' @references Schaefer A, et al. (2018). "Local-Global Parcellation of the
 #'   Human Cerebral Cortex from Intrinsic Functional Connectivity MRI."

--- a/R/data.R
+++ b/R/data.R
@@ -20,7 +20,7 @@
 #' @export
 #' @examples
 #' schaefer7_100()
-#' plot(schaefer7_100())
+#' \dontrun{plot(schaefer7_100())}
 schaefer7_100 <- function() .schaefer7_100
 #' Schaefer 7-Network 200-Parcel Atlas
 #'
@@ -42,7 +42,7 @@ schaefer7_100 <- function() .schaefer7_100
 #' @export
 #' @examples
 #' schaefer7_200()
-#' plot(schaefer7_200())
+#' \dontrun{plot(schaefer7_200())}
 schaefer7_200 <- function() .schaefer7_200
 #' Schaefer 7-Network 300-Parcel Atlas
 #'
@@ -64,7 +64,7 @@ schaefer7_200 <- function() .schaefer7_200
 #' @export
 #' @examples
 #' schaefer7_300()
-#' plot(schaefer7_300())
+#' \dontrun{plot(schaefer7_300())}
 schaefer7_300 <- function() .schaefer7_300
 #' Schaefer 7-Network 400-Parcel Atlas
 #'
@@ -86,7 +86,7 @@ schaefer7_300 <- function() .schaefer7_300
 #' @export
 #' @examples
 #' schaefer7_400()
-#' plot(schaefer7_400())
+#' \dontrun{plot(schaefer7_400())}
 schaefer7_400 <- function() .schaefer7_400
 #' Schaefer 7-Network 500-Parcel Atlas
 #'
@@ -108,7 +108,7 @@ schaefer7_400 <- function() .schaefer7_400
 #' @export
 #' @examples
 #' schaefer7_500()
-#' plot(schaefer7_500())
+#' \dontrun{plot(schaefer7_500())}
 schaefer7_500 <- function() .schaefer7_500
 #' Schaefer 7-Network 600-Parcel Atlas
 #'
@@ -130,7 +130,7 @@ schaefer7_500 <- function() .schaefer7_500
 #' @export
 #' @examples
 #' schaefer7_600()
-#' plot(schaefer7_600())
+#' \dontrun{plot(schaefer7_600())}
 schaefer7_600 <- function() .schaefer7_600
 #' Schaefer 7-Network 700-Parcel Atlas
 #'
@@ -152,7 +152,7 @@ schaefer7_600 <- function() .schaefer7_600
 #' @export
 #' @examples
 #' schaefer7_700()
-#' plot(schaefer7_700())
+#' \dontrun{plot(schaefer7_700())}
 schaefer7_700 <- function() .schaefer7_700
 #' Schaefer 7-Network 800-Parcel Atlas
 #'
@@ -174,7 +174,7 @@ schaefer7_700 <- function() .schaefer7_700
 #' @export
 #' @examples
 #' schaefer7_800()
-#' plot(schaefer7_800())
+#' \dontrun{plot(schaefer7_800())}
 schaefer7_800 <- function() .schaefer7_800
 #' Schaefer 7-Network 900-Parcel Atlas
 #'
@@ -196,7 +196,7 @@ schaefer7_800 <- function() .schaefer7_800
 #' @export
 #' @examples
 #' schaefer7_900()
-#' plot(schaefer7_900())
+#' \dontrun{plot(schaefer7_900())}
 schaefer7_900 <- function() .schaefer7_900
 #' Schaefer 7-Network 1000-Parcel Atlas
 #'
@@ -218,7 +218,7 @@ schaefer7_900 <- function() .schaefer7_900
 #' @export
 #' @examples
 #' schaefer7_1000()
-#' plot(schaefer7_1000())
+#' \dontrun{plot(schaefer7_1000())}
 schaefer7_1000 <- function() .schaefer7_1000
 # Schaefer 17-Network parcellations ----
 #' Schaefer 17-Network 100-Parcel Atlas
@@ -241,7 +241,7 @@ schaefer7_1000 <- function() .schaefer7_1000
 #' @export
 #' @examples
 #' schaefer17_100()
-#' plot(schaefer17_100())
+#' \dontrun{plot(schaefer17_100())}
 schaefer17_100 <- function() .schaefer17_100
 #' Schaefer 17-Network 200-Parcel Atlas
 #'
@@ -263,7 +263,7 @@ schaefer17_100 <- function() .schaefer17_100
 #' @export
 #' @examples
 #' schaefer17_200()
-#' plot(schaefer17_200())
+#' \dontrun{plot(schaefer17_200())}
 schaefer17_200 <- function() .schaefer17_200
 #' Schaefer 17-Network 300-Parcel Atlas
 #'
@@ -285,7 +285,7 @@ schaefer17_200 <- function() .schaefer17_200
 #' @export
 #' @examples
 #' schaefer17_300()
-#' plot(schaefer17_300())
+#' \dontrun{plot(schaefer17_300())}
 schaefer17_300 <- function() .schaefer17_300
 #' Schaefer 17-Network 400-Parcel Atlas
 #'
@@ -307,7 +307,7 @@ schaefer17_300 <- function() .schaefer17_300
 #' @export
 #' @examples
 #' schaefer17_400()
-#' plot(schaefer17_400())
+#' \dontrun{plot(schaefer17_400())}
 schaefer17_400 <- function() .schaefer17_400
 #' Schaefer 17-Network 500-Parcel Atlas
 #'
@@ -329,7 +329,7 @@ schaefer17_400 <- function() .schaefer17_400
 #' @export
 #' @examples
 #' schaefer17_500()
-#' plot(schaefer17_500())
+#' \dontrun{plot(schaefer17_500())}
 schaefer17_500 <- function() .schaefer17_500
 #' Schaefer 17-Network 600-Parcel Atlas
 #'
@@ -351,7 +351,7 @@ schaefer17_500 <- function() .schaefer17_500
 #' @export
 #' @examples
 #' schaefer17_600()
-#' plot(schaefer17_600())
+#' \dontrun{plot(schaefer17_600())}
 schaefer17_600 <- function() .schaefer17_600
 #' Schaefer 17-Network 700-Parcel Atlas
 #'
@@ -373,7 +373,7 @@ schaefer17_600 <- function() .schaefer17_600
 #' @export
 #' @examples
 #' schaefer17_700()
-#' plot(schaefer17_700())
+#' \dontrun{plot(schaefer17_700())}
 schaefer17_700 <- function() .schaefer17_700
 #' Schaefer 17-Network 800-Parcel Atlas
 #'
@@ -395,7 +395,7 @@ schaefer17_700 <- function() .schaefer17_700
 #' @export
 #' @examples
 #' schaefer17_800()
-#' plot(schaefer17_800())
+#' \dontrun{plot(schaefer17_800())}
 schaefer17_800 <- function() .schaefer17_800
 #' Schaefer 17-Network 900-Parcel Atlas
 #'
@@ -417,7 +417,7 @@ schaefer17_800 <- function() .schaefer17_800
 #' @export
 #' @examples
 #' schaefer17_900()
-#' plot(schaefer17_900())
+#' \dontrun{plot(schaefer17_900())}
 schaefer17_900 <- function() .schaefer17_900
 #' Schaefer 17-Network 1000-Parcel Atlas
 #'
@@ -439,5 +439,5 @@ schaefer17_900 <- function() .schaefer17_900
 #' @export
 #' @examples
 #' schaefer17_1000()
-#' plot(schaefer17_1000())
+#' \dontrun{plot(schaefer17_1000())}
 schaefer17_1000 <- function() .schaefer17_1000

--- a/codemeta.json
+++ b/codemeta.json
@@ -1,0 +1,160 @@
+{
+  "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
+  "@type": "SoftwareSourceCode",
+  "identifier": "ggsegSchaefer",
+  "description": "Schaefer cortical atlas for the 'ggseg' ecosystem. Provides unified 'ggseg_atlas' objects with both 2D polygon geometry and 3D vertex indices, for use with 'ggseg' and 'ggseg3d'. Includes 7-network and 17-network parcellations at resolutions from 100 to 1000 parcels.",
+  "name": "ggsegSchaefer: Schaefer Atlas for the 'ggsegverse' Ecosystem",
+  "codeRepository": "https://github.com/ggsegverse/ggsegSchaefer",
+  "issueTracker": "https://github.com/ggsegverse/ggsegSchaefer/issues",
+  "license": "https://spdx.org/licenses/MIT",
+  "version": "2.0.2",
+  "programmingLanguage": {
+    "@type": "ComputerLanguage",
+    "name": "R",
+    "url": "https://r-project.org"
+  },
+  "runtimePlatform": "R version 4.5.2 (2025-10-31)",
+  "author": [
+    {
+      "@type": "Person",
+      "givenName": "Athanasia Mo",
+      "familyName": "Mowinckel",
+      "email": "a.m.mowinckel@psykologi.uio.no",
+      "@id": "https://orcid.org/0000-0002-5756-0223"
+    },
+    {
+      "@type": "Person",
+      "givenName": "Didac",
+      "familyName": "Vidal-Pineiro",
+      "email": "d.v.pineiro@psykologi.uio.no",
+      "@id": "https://orcid.org/0000-0001-9997-9156"
+    }
+  ],
+  "contributor": [
+    {
+      "@type": "Person",
+      "givenName": "Monica",
+      "familyName": "Thieu",
+      "email": "monica.thieu@columbia.edu",
+      "@id": "https://orcid.org/0000-0002-6376-0467"
+    }
+  ],
+  "maintainer": [
+    {
+      "@type": "Person",
+      "givenName": "Athanasia Mo",
+      "familyName": "Mowinckel",
+      "email": "a.m.mowinckel@psykologi.uio.no",
+      "@id": "https://orcid.org/0000-0002-5756-0223"
+    }
+  ],
+  "softwareSuggestions": [
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "ggseg",
+      "name": "ggseg",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=ggseg"
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "ggseg3d",
+      "name": "ggseg3d",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=ggseg3d"
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "ggplot2",
+      "name": "ggplot2",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=ggplot2"
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "knitr",
+      "name": "knitr",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=knitr"
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "rmarkdown",
+      "name": "rmarkdown",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=rmarkdown"
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "testthat",
+      "name": "testthat",
+      "version": ">= 3.0.0",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=testthat"
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "vdiffr",
+      "name": "vdiffr",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=vdiffr"
+    }
+  ],
+  "softwareRequirements": {
+    "1": {
+      "@type": "SoftwareApplication",
+      "identifier": "R",
+      "name": "R",
+      "version": ">= 3.5"
+    },
+    "2": {
+      "@type": "SoftwareApplication",
+      "identifier": "ggseg.formats",
+      "name": "ggseg.formats",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=ggseg.formats"
+    },
+    "SystemRequirements": null
+  },
+  "fileSize": "NAKB"
+}

--- a/data-raw/make_atlas.R
+++ b/data-raw/make_atlas.R
@@ -63,7 +63,8 @@ for (net in networks) {
 
     src_files <- here::here(
       "data-raw",
-      c(paste0("lh.", annot_name, ".annot"), paste0("rh.", annot_name, ".annot"))
+      c(paste0("lh.", annot_name, ".annot"),
+        paste0("rh.", annot_name, ".annot"))
     )
 
     if (!all(file.exists(src_files))) next
@@ -71,7 +72,8 @@ for (net in networks) {
     file.copy(src_files, local_label, overwrite = FALSE)
 
     for (hemi in c("lh", "rh")) {
-      out_file <- file.path(resample_dir, paste0(hemi, ".", annot_name, ".annot"))
+      out_file <- file.path(
+        resample_dir, paste0(hemi, ".", annot_name, ".annot"))
       if (file.exists(out_file)) next
       mri_surf2surf_rereg(
         subject = "fsaverage",
@@ -97,7 +99,8 @@ for (net in networks) {
 
     annot_files <- file.path(
       resample_dir,
-      c(paste0("lh.", annot_name, ".annot"), paste0("rh.", annot_name, ".annot"))
+      c(paste0("lh.", annot_name, ".annot"),
+        paste0("rh.", annot_name, ".annot"))
     )
 
     if (!all(file.exists(annot_files))) next

--- a/tests/testthat/test-data.R
+++ b/tests/testthat/test-data.R
@@ -38,6 +38,7 @@ describe("schaefer7_400 atlas rendering", {
 
   it("renders with ggseg3d", {
     skip_if_not_installed("ggseg3d")
+    skip_if_not_installed("ggseg.meshes")
     p <- ggseg3d::ggseg3d(atlas = schaefer7_400())
     expect_s3_class(p, c("plotly", "htmlwidget"))
   })

--- a/tests/testthat/test-data.R
+++ b/tests/testthat/test-data.R
@@ -1,5 +1,11 @@
-atlas_names_7 <- paste0("schaefer7_", c(100, 200, 300, 400, 500, 600, 700, 800, 900, 1000))
-atlas_names_17 <- paste0("schaefer17_", c(100, 200, 300, 400, 500, 600, 700, 800, 900, 1000))
+atlas_names_7 <- paste0(
+  "schaefer7_",
+  c(100, 200, 300, 400, 500, 600, 700, 800, 900, 1000)
+)
+atlas_names_17 <- paste0(
+  "schaefer17_",
+  c(100, 200, 300, 400, 500, 600, 700, 800, 900, 1000)
+)
 
 for (nm in c(atlas_names_7, atlas_names_17)) {
   atlas <- do.call(nm, list())


### PR DESCRIPTION
## Summary
- Atlas v2 format conversion with family/type tags
- Fixed ggseg3d test skips for missing ggseg.meshes
- Added dev ggseg remote for ggplot2 4.0 compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)