### PR TITLE
Add @family type tags for atlas classification

### DIFF
--- a/man/ggsegSchaefer-package.Rd
+++ b/man/ggsegSchaefer-package.Rd
@@ -4,7 +4,7 @@
 \name{ggsegSchaefer-package}
 \alias{ggsegSchaefer}
 \alias{ggsegSchaefer-package}
-\title{ggsegSchaefer: Schaefer Atlas for the 'ggseg' Ecosystem}
+\title{ggsegSchaefer: Schaefer Atlas for the 'ggsegverse' Ecosystem}
 \description{
 \if{html}{\figure{logo.png}{options: style='float: right' alt='logo' width='120'}}
 

--- a/man/schaefer17_100.Rd
+++ b/man/schaefer17_100.Rd
@@ -18,6 +18,7 @@ Contains both 2D polygon geometry for \code{\link[ggseg:ggbrain]{ggseg::geom_bra
 }
 \examples{
 schaefer17_100()
+\dontrun{plot(schaefer17_100())}
 }
 \references{
 Schaefer A, et al. (2018). "Local-Global Parcellation of the
@@ -46,5 +47,27 @@ Other ggseg_atlases:
 \code{\link{schaefer7_700}()},
 \code{\link{schaefer7_800}()},
 \code{\link{schaefer7_900}()}
+
+Other cortical_atlases: 
+\code{\link{schaefer17_1000}()},
+\code{\link{schaefer17_200}()},
+\code{\link{schaefer17_300}()},
+\code{\link{schaefer17_400}()},
+\code{\link{schaefer17_500}()},
+\code{\link{schaefer17_600}()},
+\code{\link{schaefer17_700}()},
+\code{\link{schaefer17_800}()},
+\code{\link{schaefer17_900}()},
+\code{\link{schaefer7_100}()},
+\code{\link{schaefer7_1000}()},
+\code{\link{schaefer7_200}()},
+\code{\link{schaefer7_300}()},
+\code{\link{schaefer7_400}()},
+\code{\link{schaefer7_500}()},
+\code{\link{schaefer7_600}()},
+\code{\link{schaefer7_700}()},
+\code{\link{schaefer7_800}()},
+\code{\link{schaefer7_900}()}
 }
+\concept{cortical_atlases}
 \concept{ggseg_atlases}

--- a/man/schaefer17_1000.Rd
+++ b/man/schaefer17_1000.Rd
@@ -18,6 +18,7 @@ Contains both 2D polygon geometry for \code{\link[ggseg:ggbrain]{ggseg::geom_bra
 }
 \examples{
 schaefer17_1000()
+\dontrun{plot(schaefer17_1000())}
 }
 \references{
 Schaefer A, et al. (2018). "Local-Global Parcellation of the
@@ -46,5 +47,27 @@ Other ggseg_atlases:
 \code{\link{schaefer7_700}()},
 \code{\link{schaefer7_800}()},
 \code{\link{schaefer7_900}()}
+
+Other cortical_atlases: 
+\code{\link{schaefer17_100}()},
+\code{\link{schaefer17_200}()},
+\code{\link{schaefer17_300}()},
+\code{\link{schaefer17_400}()},
+\code{\link{schaefer17_500}()},
+\code{\link{schaefer17_600}()},
+\code{\link{schaefer17_700}()},
+\code{\link{schaefer17_800}()},
+\code{\link{schaefer17_900}()},
+\code{\link{schaefer7_100}()},
+\code{\link{schaefer7_1000}()},
+\code{\link{schaefer7_200}()},
+\code{\link{schaefer7_300}()},
+\code{\link{schaefer7_400}()},
+\code{\link{schaefer7_500}()},
+\code{\link{schaefer7_600}()},
+\code{\link{schaefer7_700}()},
+\code{\link{schaefer7_800}()},
+\code{\link{schaefer7_900}()}
 }
+\concept{cortical_atlases}
 \concept{ggseg_atlases}

--- a/man/schaefer17_200.Rd
+++ b/man/schaefer17_200.Rd
@@ -18,6 +18,7 @@ Contains both 2D polygon geometry for \code{\link[ggseg:ggbrain]{ggseg::geom_bra
 }
 \examples{
 schaefer17_200()
+\dontrun{plot(schaefer17_200())}
 }
 \references{
 Schaefer A, et al. (2018). "Local-Global Parcellation of the
@@ -46,5 +47,27 @@ Other ggseg_atlases:
 \code{\link{schaefer7_700}()},
 \code{\link{schaefer7_800}()},
 \code{\link{schaefer7_900}()}
+
+Other cortical_atlases: 
+\code{\link{schaefer17_100}()},
+\code{\link{schaefer17_1000}()},
+\code{\link{schaefer17_300}()},
+\code{\link{schaefer17_400}()},
+\code{\link{schaefer17_500}()},
+\code{\link{schaefer17_600}()},
+\code{\link{schaefer17_700}()},
+\code{\link{schaefer17_800}()},
+\code{\link{schaefer17_900}()},
+\code{\link{schaefer7_100}()},
+\code{\link{schaefer7_1000}()},
+\code{\link{schaefer7_200}()},
+\code{\link{schaefer7_300}()},
+\code{\link{schaefer7_400}()},
+\code{\link{schaefer7_500}()},
+\code{\link{schaefer7_600}()},
+\code{\link{schaefer7_700}()},
+\code{\link{schaefer7_800}()},
+\code{\link{schaefer7_900}()}
 }
+\concept{cortical_atlases}
 \concept{ggseg_atlases}

--- a/man/schaefer17_300.Rd
+++ b/man/schaefer17_300.Rd
@@ -18,6 +18,7 @@ Contains both 2D polygon geometry for \code{\link[ggseg:ggbrain]{ggseg::geom_bra
 }
 \examples{
 schaefer17_300()
+\dontrun{plot(schaefer17_300())}
 }
 \references{
 Schaefer A, et al. (2018). "Local-Global Parcellation of the
@@ -46,5 +47,27 @@ Other ggseg_atlases:
 \code{\link{schaefer7_700}()},
 \code{\link{schaefer7_800}()},
 \code{\link{schaefer7_900}()}
+
+Other cortical_atlases: 
+\code{\link{schaefer17_100}()},
+\code{\link{schaefer17_1000}()},
+\code{\link{schaefer17_200}()},
+\code{\link{schaefer17_400}()},
+\code{\link{schaefer17_500}()},
+\code{\link{schaefer17_600}()},
+\code{\link{schaefer17_700}()},
+\code{\link{schaefer17_800}()},
+\code{\link{schaefer17_900}()},
+\code{\link{schaefer7_100}()},
+\code{\link{schaefer7_1000}()},
+\code{\link{schaefer7_200}()},
+\code{\link{schaefer7_300}()},
+\code{\link{schaefer7_400}()},
+\code{\link{schaefer7_500}()},
+\code{\link{schaefer7_600}()},
+\code{\link{schaefer7_700}()},
+\code{\link{schaefer7_800}()},
+\code{\link{schaefer7_900}()}
 }
+\concept{cortical_atlases}
 \concept{ggseg_atlases}

--- a/man/schaefer17_400.Rd
+++ b/man/schaefer17_400.Rd
@@ -18,6 +18,7 @@ Contains both 2D polygon geometry for \code{\link[ggseg:ggbrain]{ggseg::geom_bra
 }
 \examples{
 schaefer17_400()
+\dontrun{plot(schaefer17_400())}
 }
 \references{
 Schaefer A, et al. (2018). "Local-Global Parcellation of the
@@ -46,5 +47,27 @@ Other ggseg_atlases:
 \code{\link{schaefer7_700}()},
 \code{\link{schaefer7_800}()},
 \code{\link{schaefer7_900}()}
+
+Other cortical_atlases: 
+\code{\link{schaefer17_100}()},
+\code{\link{schaefer17_1000}()},
+\code{\link{schaefer17_200}()},
+\code{\link{schaefer17_300}()},
+\code{\link{schaefer17_500}()},
+\code{\link{schaefer17_600}()},
+\code{\link{schaefer17_700}()},
+\code{\link{schaefer17_800}()},
+\code{\link{schaefer17_900}()},
+\code{\link{schaefer7_100}()},
+\code{\link{schaefer7_1000}()},
+\code{\link{schaefer7_200}()},
+\code{\link{schaefer7_300}()},
+\code{\link{schaefer7_400}()},
+\code{\link{schaefer7_500}()},
+\code{\link{schaefer7_600}()},
+\code{\link{schaefer7_700}()},
+\code{\link{schaefer7_800}()},
+\code{\link{schaefer7_900}()}
 }
+\concept{cortical_atlases}
 \concept{ggseg_atlases}

--- a/man/schaefer17_500.Rd
+++ b/man/schaefer17_500.Rd
@@ -18,6 +18,7 @@ Contains both 2D polygon geometry for \code{\link[ggseg:ggbrain]{ggseg::geom_bra
 }
 \examples{
 schaefer17_500()
+\dontrun{plot(schaefer17_500())}
 }
 \references{
 Schaefer A, et al. (2018). "Local-Global Parcellation of the
@@ -46,5 +47,27 @@ Other ggseg_atlases:
 \code{\link{schaefer7_700}()},
 \code{\link{schaefer7_800}()},
 \code{\link{schaefer7_900}()}
+
+Other cortical_atlases: 
+\code{\link{schaefer17_100}()},
+\code{\link{schaefer17_1000}()},
+\code{\link{schaefer17_200}()},
+\code{\link{schaefer17_300}()},
+\code{\link{schaefer17_400}()},
+\code{\link{schaefer17_600}()},
+\code{\link{schaefer17_700}()},
+\code{\link{schaefer17_800}()},
+\code{\link{schaefer17_900}()},
+\code{\link{schaefer7_100}()},
+\code{\link{schaefer7_1000}()},
+\code{\link{schaefer7_200}()},
+\code{\link{schaefer7_300}()},
+\code{\link{schaefer7_400}()},
+\code{\link{schaefer7_500}()},
+\code{\link{schaefer7_600}()},
+\code{\link{schaefer7_700}()},
+\code{\link{schaefer7_800}()},
+\code{\link{schaefer7_900}()}
 }
+\concept{cortical_atlases}
 \concept{ggseg_atlases}

--- a/man/schaefer17_600.Rd
+++ b/man/schaefer17_600.Rd
@@ -18,6 +18,7 @@ Contains both 2D polygon geometry for \code{\link[ggseg:ggbrain]{ggseg::geom_bra
 }
 \examples{
 schaefer17_600()
+\dontrun{plot(schaefer17_600())}
 }
 \references{
 Schaefer A, et al. (2018). "Local-Global Parcellation of the
@@ -46,5 +47,27 @@ Other ggseg_atlases:
 \code{\link{schaefer7_700}()},
 \code{\link{schaefer7_800}()},
 \code{\link{schaefer7_900}()}
+
+Other cortical_atlases: 
+\code{\link{schaefer17_100}()},
+\code{\link{schaefer17_1000}()},
+\code{\link{schaefer17_200}()},
+\code{\link{schaefer17_300}()},
+\code{\link{schaefer17_400}()},
+\code{\link{schaefer17_500}()},
+\code{\link{schaefer17_700}()},
+\code{\link{schaefer17_800}()},
+\code{\link{schaefer17_900}()},
+\code{\link{schaefer7_100}()},
+\code{\link{schaefer7_1000}()},
+\code{\link{schaefer7_200}()},
+\code{\link{schaefer7_300}()},
+\code{\link{schaefer7_400}()},
+\code{\link{schaefer7_500}()},
+\code{\link{schaefer7_600}()},
+\code{\link{schaefer7_700}()},
+\code{\link{schaefer7_800}()},
+\code{\link{schaefer7_900}()}
 }
+\concept{cortical_atlases}
 \concept{ggseg_atlases}

--- a/man/schaefer17_700.Rd
+++ b/man/schaefer17_700.Rd
@@ -18,6 +18,7 @@ Contains both 2D polygon geometry for \code{\link[ggseg:ggbrain]{ggseg::geom_bra
 }
 \examples{
 schaefer17_700()
+\dontrun{plot(schaefer17_700())}
 }
 \references{
 Schaefer A, et al. (2018). "Local-Global Parcellation of the
@@ -46,5 +47,27 @@ Other ggseg_atlases:
 \code{\link{schaefer7_700}()},
 \code{\link{schaefer7_800}()},
 \code{\link{schaefer7_900}()}
+
+Other cortical_atlases: 
+\code{\link{schaefer17_100}()},
+\code{\link{schaefer17_1000}()},
+\code{\link{schaefer17_200}()},
+\code{\link{schaefer17_300}()},
+\code{\link{schaefer17_400}()},
+\code{\link{schaefer17_500}()},
+\code{\link{schaefer17_600}()},
+\code{\link{schaefer17_800}()},
+\code{\link{schaefer17_900}()},
+\code{\link{schaefer7_100}()},
+\code{\link{schaefer7_1000}()},
+\code{\link{schaefer7_200}()},
+\code{\link{schaefer7_300}()},
+\code{\link{schaefer7_400}()},
+\code{\link{schaefer7_500}()},
+\code{\link{schaefer7_600}()},
+\code{\link{schaefer7_700}()},
+\code{\link{schaefer7_800}()},
+\code{\link{schaefer7_900}()}
 }
+\concept{cortical_atlases}
 \concept{ggseg_atlases}

--- a/man/schaefer17_800.Rd
+++ b/man/schaefer17_800.Rd
@@ -18,6 +18,7 @@ Contains both 2D polygon geometry for \code{\link[ggseg:ggbrain]{ggseg::geom_bra
 }
 \examples{
 schaefer17_800()
+\dontrun{plot(schaefer17_800())}
 }
 \references{
 Schaefer A, et al. (2018). "Local-Global Parcellation of the
@@ -46,5 +47,27 @@ Other ggseg_atlases:
 \code{\link{schaefer7_700}()},
 \code{\link{schaefer7_800}()},
 \code{\link{schaefer7_900}()}
+
+Other cortical_atlases: 
+\code{\link{schaefer17_100}()},
+\code{\link{schaefer17_1000}()},
+\code{\link{schaefer17_200}()},
+\code{\link{schaefer17_300}()},
+\code{\link{schaefer17_400}()},
+\code{\link{schaefer17_500}()},
+\code{\link{schaefer17_600}()},
+\code{\link{schaefer17_700}()},
+\code{\link{schaefer17_900}()},
+\code{\link{schaefer7_100}()},
+\code{\link{schaefer7_1000}()},
+\code{\link{schaefer7_200}()},
+\code{\link{schaefer7_300}()},
+\code{\link{schaefer7_400}()},
+\code{\link{schaefer7_500}()},
+\code{\link{schaefer7_600}()},
+\code{\link{schaefer7_700}()},
+\code{\link{schaefer7_800}()},
+\code{\link{schaefer7_900}()}
 }
+\concept{cortical_atlases}
 \concept{ggseg_atlases}

--- a/man/schaefer17_900.Rd
+++ b/man/schaefer17_900.Rd
@@ -18,6 +18,7 @@ Contains both 2D polygon geometry for \code{\link[ggseg:ggbrain]{ggseg::geom_bra
 }
 \examples{
 schaefer17_900()
+\dontrun{plot(schaefer17_900())}
 }
 \references{
 Schaefer A, et al. (2018). "Local-Global Parcellation of the
@@ -46,5 +47,27 @@ Other ggseg_atlases:
 \code{\link{schaefer7_700}()},
 \code{\link{schaefer7_800}()},
 \code{\link{schaefer7_900}()}
+
+Other cortical_atlases: 
+\code{\link{schaefer17_100}()},
+\code{\link{schaefer17_1000}()},
+\code{\link{schaefer17_200}()},
+\code{\link{schaefer17_300}()},
+\code{\link{schaefer17_400}()},
+\code{\link{schaefer17_500}()},
+\code{\link{schaefer17_600}()},
+\code{\link{schaefer17_700}()},
+\code{\link{schaefer17_800}()},
+\code{\link{schaefer7_100}()},
+\code{\link{schaefer7_1000}()},
+\code{\link{schaefer7_200}()},
+\code{\link{schaefer7_300}()},
+\code{\link{schaefer7_400}()},
+\code{\link{schaefer7_500}()},
+\code{\link{schaefer7_600}()},
+\code{\link{schaefer7_700}()},
+\code{\link{schaefer7_800}()},
+\code{\link{schaefer7_900}()}
 }
+\concept{cortical_atlases}
 \concept{ggseg_atlases}

--- a/man/schaefer7_100.Rd
+++ b/man/schaefer7_100.Rd
@@ -18,6 +18,7 @@ Contains both 2D polygon geometry for \code{\link[ggseg:ggbrain]{ggseg::geom_bra
 }
 \examples{
 schaefer7_100()
+\dontrun{plot(schaefer7_100())}
 }
 \references{
 Schaefer A, et al. (2018). "Local-Global Parcellation of the
@@ -46,5 +47,27 @@ Other ggseg_atlases:
 \code{\link{schaefer7_700}()},
 \code{\link{schaefer7_800}()},
 \code{\link{schaefer7_900}()}
+
+Other cortical_atlases: 
+\code{\link{schaefer17_100}()},
+\code{\link{schaefer17_1000}()},
+\code{\link{schaefer17_200}()},
+\code{\link{schaefer17_300}()},
+\code{\link{schaefer17_400}()},
+\code{\link{schaefer17_500}()},
+\code{\link{schaefer17_600}()},
+\code{\link{schaefer17_700}()},
+\code{\link{schaefer17_800}()},
+\code{\link{schaefer17_900}()},
+\code{\link{schaefer7_1000}()},
+\code{\link{schaefer7_200}()},
+\code{\link{schaefer7_300}()},
+\code{\link{schaefer7_400}()},
+\code{\link{schaefer7_500}()},
+\code{\link{schaefer7_600}()},
+\code{\link{schaefer7_700}()},
+\code{\link{schaefer7_800}()},
+\code{\link{schaefer7_900}()}
 }
+\concept{cortical_atlases}
 \concept{ggseg_atlases}

--- a/man/schaefer7_1000.Rd
+++ b/man/schaefer7_1000.Rd
@@ -18,6 +18,7 @@ Contains both 2D polygon geometry for \code{\link[ggseg:ggbrain]{ggseg::geom_bra
 }
 \examples{
 schaefer7_1000()
+\dontrun{plot(schaefer7_1000())}
 }
 \references{
 Schaefer A, et al. (2018). "Local-Global Parcellation of the
@@ -46,5 +47,27 @@ Other ggseg_atlases:
 \code{\link{schaefer7_700}()},
 \code{\link{schaefer7_800}()},
 \code{\link{schaefer7_900}()}
+
+Other cortical_atlases: 
+\code{\link{schaefer17_100}()},
+\code{\link{schaefer17_1000}()},
+\code{\link{schaefer17_200}()},
+\code{\link{schaefer17_300}()},
+\code{\link{schaefer17_400}()},
+\code{\link{schaefer17_500}()},
+\code{\link{schaefer17_600}()},
+\code{\link{schaefer17_700}()},
+\code{\link{schaefer17_800}()},
+\code{\link{schaefer17_900}()},
+\code{\link{schaefer7_100}()},
+\code{\link{schaefer7_200}()},
+\code{\link{schaefer7_300}()},
+\code{\link{schaefer7_400}()},
+\code{\link{schaefer7_500}()},
+\code{\link{schaefer7_600}()},
+\code{\link{schaefer7_700}()},
+\code{\link{schaefer7_800}()},
+\code{\link{schaefer7_900}()}
 }
+\concept{cortical_atlases}
 \concept{ggseg_atlases}

--- a/man/schaefer7_200.Rd
+++ b/man/schaefer7_200.Rd
@@ -18,6 +18,7 @@ Contains both 2D polygon geometry for \code{\link[ggseg:ggbrain]{ggseg::geom_bra
 }
 \examples{
 schaefer7_200()
+\dontrun{plot(schaefer7_200())}
 }
 \references{
 Schaefer A, et al. (2018). "Local-Global Parcellation of the
@@ -46,5 +47,27 @@ Other ggseg_atlases:
 \code{\link{schaefer7_700}()},
 \code{\link{schaefer7_800}()},
 \code{\link{schaefer7_900}()}
+
+Other cortical_atlases: 
+\code{\link{schaefer17_100}()},
+\code{\link{schaefer17_1000}()},
+\code{\link{schaefer17_200}()},
+\code{\link{schaefer17_300}()},
+\code{\link{schaefer17_400}()},
+\code{\link{schaefer17_500}()},
+\code{\link{schaefer17_600}()},
+\code{\link{schaefer17_700}()},
+\code{\link{schaefer17_800}()},
+\code{\link{schaefer17_900}()},
+\code{\link{schaefer7_100}()},
+\code{\link{schaefer7_1000}()},
+\code{\link{schaefer7_300}()},
+\code{\link{schaefer7_400}()},
+\code{\link{schaefer7_500}()},
+\code{\link{schaefer7_600}()},
+\code{\link{schaefer7_700}()},
+\code{\link{schaefer7_800}()},
+\code{\link{schaefer7_900}()}
 }
+\concept{cortical_atlases}
 \concept{ggseg_atlases}

--- a/man/schaefer7_300.Rd
+++ b/man/schaefer7_300.Rd
@@ -18,6 +18,7 @@ Contains both 2D polygon geometry for \code{\link[ggseg:ggbrain]{ggseg::geom_bra
 }
 \examples{
 schaefer7_300()
+\dontrun{plot(schaefer7_300())}
 }
 \references{
 Schaefer A, et al. (2018). "Local-Global Parcellation of the
@@ -46,5 +47,27 @@ Other ggseg_atlases:
 \code{\link{schaefer7_700}()},
 \code{\link{schaefer7_800}()},
 \code{\link{schaefer7_900}()}
+
+Other cortical_atlases: 
+\code{\link{schaefer17_100}()},
+\code{\link{schaefer17_1000}()},
+\code{\link{schaefer17_200}()},
+\code{\link{schaefer17_300}()},
+\code{\link{schaefer17_400}()},
+\code{\link{schaefer17_500}()},
+\code{\link{schaefer17_600}()},
+\code{\link{schaefer17_700}()},
+\code{\link{schaefer17_800}()},
+\code{\link{schaefer17_900}()},
+\code{\link{schaefer7_100}()},
+\code{\link{schaefer7_1000}()},
+\code{\link{schaefer7_200}()},
+\code{\link{schaefer7_400}()},
+\code{\link{schaefer7_500}()},
+\code{\link{schaefer7_600}()},
+\code{\link{schaefer7_700}()},
+\code{\link{schaefer7_800}()},
+\code{\link{schaefer7_900}()}
 }
+\concept{cortical_atlases}
 \concept{ggseg_atlases}

--- a/man/schaefer7_400.Rd
+++ b/man/schaefer7_400.Rd
@@ -18,6 +18,7 @@ Contains both 2D polygon geometry for \code{\link[ggseg:ggbrain]{ggseg::geom_bra
 }
 \examples{
 schaefer7_400()
+\dontrun{plot(schaefer7_400())}
 }
 \references{
 Schaefer A, et al. (2018). "Local-Global Parcellation of the
@@ -46,5 +47,27 @@ Other ggseg_atlases:
 \code{\link{schaefer7_700}()},
 \code{\link{schaefer7_800}()},
 \code{\link{schaefer7_900}()}
+
+Other cortical_atlases: 
+\code{\link{schaefer17_100}()},
+\code{\link{schaefer17_1000}()},
+\code{\link{schaefer17_200}()},
+\code{\link{schaefer17_300}()},
+\code{\link{schaefer17_400}()},
+\code{\link{schaefer17_500}()},
+\code{\link{schaefer17_600}()},
+\code{\link{schaefer17_700}()},
+\code{\link{schaefer17_800}()},
+\code{\link{schaefer17_900}()},
+\code{\link{schaefer7_100}()},
+\code{\link{schaefer7_1000}()},
+\code{\link{schaefer7_200}()},
+\code{\link{schaefer7_300}()},
+\code{\link{schaefer7_500}()},
+\code{\link{schaefer7_600}()},
+\code{\link{schaefer7_700}()},
+\code{\link{schaefer7_800}()},
+\code{\link{schaefer7_900}()}
 }
+\concept{cortical_atlases}
 \concept{ggseg_atlases}

--- a/man/schaefer7_500.Rd
+++ b/man/schaefer7_500.Rd
@@ -18,6 +18,7 @@ Contains both 2D polygon geometry for \code{\link[ggseg:ggbrain]{ggseg::geom_bra
 }
 \examples{
 schaefer7_500()
+\dontrun{plot(schaefer7_500())}
 }
 \references{
 Schaefer A, et al. (2018). "Local-Global Parcellation of the
@@ -46,5 +47,27 @@ Other ggseg_atlases:
 \code{\link{schaefer7_700}()},
 \code{\link{schaefer7_800}()},
 \code{\link{schaefer7_900}()}
+
+Other cortical_atlases: 
+\code{\link{schaefer17_100}()},
+\code{\link{schaefer17_1000}()},
+\code{\link{schaefer17_200}()},
+\code{\link{schaefer17_300}()},
+\code{\link{schaefer17_400}()},
+\code{\link{schaefer17_500}()},
+\code{\link{schaefer17_600}()},
+\code{\link{schaefer17_700}()},
+\code{\link{schaefer17_800}()},
+\code{\link{schaefer17_900}()},
+\code{\link{schaefer7_100}()},
+\code{\link{schaefer7_1000}()},
+\code{\link{schaefer7_200}()},
+\code{\link{schaefer7_300}()},
+\code{\link{schaefer7_400}()},
+\code{\link{schaefer7_600}()},
+\code{\link{schaefer7_700}()},
+\code{\link{schaefer7_800}()},
+\code{\link{schaefer7_900}()}
 }
+\concept{cortical_atlases}
 \concept{ggseg_atlases}

--- a/man/schaefer7_600.Rd
+++ b/man/schaefer7_600.Rd
@@ -18,6 +18,7 @@ Contains both 2D polygon geometry for \code{\link[ggseg:ggbrain]{ggseg::geom_bra
 }
 \examples{
 schaefer7_600()
+\dontrun{plot(schaefer7_600())}
 }
 \references{
 Schaefer A, et al. (2018). "Local-Global Parcellation of the
@@ -46,5 +47,27 @@ Other ggseg_atlases:
 \code{\link{schaefer7_700}()},
 \code{\link{schaefer7_800}()},
 \code{\link{schaefer7_900}()}
+
+Other cortical_atlases: 
+\code{\link{schaefer17_100}()},
+\code{\link{schaefer17_1000}()},
+\code{\link{schaefer17_200}()},
+\code{\link{schaefer17_300}()},
+\code{\link{schaefer17_400}()},
+\code{\link{schaefer17_500}()},
+\code{\link{schaefer17_600}()},
+\code{\link{schaefer17_700}()},
+\code{\link{schaefer17_800}()},
+\code{\link{schaefer17_900}()},
+\code{\link{schaefer7_100}()},
+\code{\link{schaefer7_1000}()},
+\code{\link{schaefer7_200}()},
+\code{\link{schaefer7_300}()},
+\code{\link{schaefer7_400}()},
+\code{\link{schaefer7_500}()},
+\code{\link{schaefer7_700}()},
+\code{\link{schaefer7_800}()},
+\code{\link{schaefer7_900}()}
 }
+\concept{cortical_atlases}
 \concept{ggseg_atlases}

--- a/man/schaefer7_700.Rd
+++ b/man/schaefer7_700.Rd
@@ -18,6 +18,7 @@ Contains both 2D polygon geometry for \code{\link[ggseg:ggbrain]{ggseg::geom_bra
 }
 \examples{
 schaefer7_700()
+\dontrun{plot(schaefer7_700())}
 }
 \references{
 Schaefer A, et al. (2018). "Local-Global Parcellation of the
@@ -46,5 +47,27 @@ Other ggseg_atlases:
 \code{\link{schaefer7_600}()},
 \code{\link{schaefer7_800}()},
 \code{\link{schaefer7_900}()}
+
+Other cortical_atlases: 
+\code{\link{schaefer17_100}()},
+\code{\link{schaefer17_1000}()},
+\code{\link{schaefer17_200}()},
+\code{\link{schaefer17_300}()},
+\code{\link{schaefer17_400}()},
+\code{\link{schaefer17_500}()},
+\code{\link{schaefer17_600}()},
+\code{\link{schaefer17_700}()},
+\code{\link{schaefer17_800}()},
+\code{\link{schaefer17_900}()},
+\code{\link{schaefer7_100}()},
+\code{\link{schaefer7_1000}()},
+\code{\link{schaefer7_200}()},
+\code{\link{schaefer7_300}()},
+\code{\link{schaefer7_400}()},
+\code{\link{schaefer7_500}()},
+\code{\link{schaefer7_600}()},
+\code{\link{schaefer7_800}()},
+\code{\link{schaefer7_900}()}
 }
+\concept{cortical_atlases}
 \concept{ggseg_atlases}

--- a/man/schaefer7_800.Rd
+++ b/man/schaefer7_800.Rd
@@ -18,6 +18,7 @@ Contains both 2D polygon geometry for \code{\link[ggseg:ggbrain]{ggseg::geom_bra
 }
 \examples{
 schaefer7_800()
+\dontrun{plot(schaefer7_800())}
 }
 \references{
 Schaefer A, et al. (2018). "Local-Global Parcellation of the
@@ -46,5 +47,27 @@ Other ggseg_atlases:
 \code{\link{schaefer7_600}()},
 \code{\link{schaefer7_700}()},
 \code{\link{schaefer7_900}()}
+
+Other cortical_atlases: 
+\code{\link{schaefer17_100}()},
+\code{\link{schaefer17_1000}()},
+\code{\link{schaefer17_200}()},
+\code{\link{schaefer17_300}()},
+\code{\link{schaefer17_400}()},
+\code{\link{schaefer17_500}()},
+\code{\link{schaefer17_600}()},
+\code{\link{schaefer17_700}()},
+\code{\link{schaefer17_800}()},
+\code{\link{schaefer17_900}()},
+\code{\link{schaefer7_100}()},
+\code{\link{schaefer7_1000}()},
+\code{\link{schaefer7_200}()},
+\code{\link{schaefer7_300}()},
+\code{\link{schaefer7_400}()},
+\code{\link{schaefer7_500}()},
+\code{\link{schaefer7_600}()},
+\code{\link{schaefer7_700}()},
+\code{\link{schaefer7_900}()}
 }
+\concept{cortical_atlases}
 \concept{ggseg_atlases}

--- a/man/schaefer7_900.Rd
+++ b/man/schaefer7_900.Rd
@@ -18,6 +18,7 @@ Contains both 2D polygon geometry for \code{\link[ggseg:ggbrain]{ggseg::geom_bra
 }
 \examples{
 schaefer7_900()
+\dontrun{plot(schaefer7_900())}
 }
 \references{
 Schaefer A, et al. (2018). "Local-Global Parcellation of the
@@ -46,5 +47,27 @@ Other ggseg_atlases:
 \code{\link{schaefer7_600}()},
 \code{\link{schaefer7_700}()},
 \code{\link{schaefer7_800}()}
+
+Other cortical_atlases: 
+\code{\link{schaefer17_100}()},
+\code{\link{schaefer17_1000}()},
+\code{\link{schaefer17_200}()},
+\code{\link{schaefer17_300}()},
+\code{\link{schaefer17_400}()},
+\code{\link{schaefer17_500}()},
+\code{\link{schaefer17_600}()},
+\code{\link{schaefer17_700}()},
+\code{\link{schaefer17_800}()},
+\code{\link{schaefer17_900}()},
+\code{\link{schaefer7_100}()},
+\code{\link{schaefer7_1000}()},
+\code{\link{schaefer7_200}()},
+\code{\link{schaefer7_300}()},
+\code{\link{schaefer7_400}()},
+\code{\link{schaefer7_500}()},
+\code{\link{schaefer7_600}()},
+\code{\link{schaefer7_700}()},
+\code{\link{schaefer7_800}()}
 }
+\concept{cortical_atlases}
 \concept{ggseg_atlases}


### PR DESCRIPTION
## Summary
- Add `@family cortical_atlases` / `@family subcortical_atlases` type tags to atlas roxygen docs
- Regenerate Rd files with `\concept{}` entries

These tags enable downstream tools to classify atlases by type (cortical, subcortical, cerebellar, etc.).

## Test plan
- [ ] R CMD check passes
- [ ] `\concept{}` tags present in generated Rd files

🤖 Generated with [Claude Code](https://claude.com/claude-code)