### PR TITLE
test: use ggseg::brain_test_plot() for the snapshot render

### DIFF
--- a/tests/testthat/test-data.R
+++ b/tests/testthat/test-data.R
@@ -25,21 +25,11 @@ for (nm in c(atlas_names_7, atlas_names_17)) {
 describe("schaefer7_400 atlas rendering", {
   it("renders with ggseg", {
     skip_if_not_installed("ggseg")
-    skip_if_not_installed("ggplot2")
     skip_if_not_installed("vdiffr")
-    p <- ggplot2::ggplot() +
-      ggseg::geom_brain(
-        atlas = schaefer7_400(),
-        mapping = ggplot2::aes(fill = label),
-        position = ggseg::position_brain(hemi ~ view),
-        show.legend = FALSE
-      ) +
-      ggplot2::scale_fill_manual(
-        values = schaefer7_400()$palette,
-        na.value = "grey"
-      ) +
-      ggplot2::theme_void()
-    vdiffr::expect_doppelganger("schaefer7_400-2d", p)
+    vdiffr::expect_doppelganger(
+      "schaefer7_400-2d",
+      ggseg::brain_test_plot(schaefer7_400())
+    )
   })
 
   it("renders with ggseg3d", {


### PR DESCRIPTION
## Summary
Replaces the hand-rolled `ggplot() + geom_brain() + scale_fill_manual() + theme_void()` snapshot block with the shared `ggseg::brain_test_plot()` helper. The render is byte-identical (same construction), so the committed `vdiffr` snapshot is unchanged — CI's own vdiffr run confirms it. Keeps the atlas snapshot text-free and consistent with the rest of the ggsegverse.

## Test plan
- vdiffr snapshot unchanged; R-CMD-check green (installs dev `ggseg` with `brain_test_plot()` via `Remotes`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)